### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ i18n-embed = { version = "0.15", features = [
     "desktop-requester",
 ] }
 
-mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.2" }
+mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.3" }

--- a/mxl-base/CHANGELOG.md
+++ b/mxl-base/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+
+## [0.2.5](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.4...mxl-base-v0.2.5) - 2024-11-20
+
+### Other
+
+- cleanup cargo dependencies
+
 ## [v0.2.4](https://github.com/x-software-com/mxl-base/compare/e6cc51322b5dce2f6fe3e0345f848e3758ef5983..v0.2.4) - 2024-09-02
 #### Bug Fixes
 - add workaround to print the current log file name - ([5770dc3](https://github.com/x-software-com/mxl-base/commit/5770dc36341c4fce26a8d906ec7af3066aa46533)) - acpiccolo

--- a/mxl-base/Cargo.toml
+++ b/mxl-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-base"
-version = "0.2.4"
+version = "0.2.5"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true

--- a/mxl-investigator/CHANGELOG.md
+++ b/mxl-investigator/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+
+## [0.1.19](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.18...mxl-investigator-v0.1.19) - 2024-11-20
+
+### Other
+
+- *(mxl-investigator)* fix nightly clippy warning
+- *(mxl-investigator)* fix unused_variables warning when sysinfo feature is disabled
+- cleanup cargo dependencies
+
 ## [v0.1.18](https://github.com/x-software-com/mxl-investigator/compare/992895ce29d3778d3a01f0b6041e889780e2471a..v0.1.18) - 2024-09-02
 #### Miscellaneous Chores
 - update mxl-relm4-components dependency to v0.2.2 - ([992895c](https://github.com/x-software-com/mxl-investigator/commit/992895ce29d3778d3a01f0b6041e889780e2471a)) - acpiccolo

--- a/mxl-investigator/Cargo.toml
+++ b/mxl-investigator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-investigator"
-version = "0.1.18"
+version = "0.1.19"
 description = "This is a component of the X-Software MXL product line."
 readme = "README.md"
 license.workspace = true

--- a/mxl-player-components/CHANGELOG.md
+++ b/mxl-player-components/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+
+## [0.1.1](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.0...mxl-player-components-v0.1.1) - 2024-11-20
+
+### Other
+
+- *(mxl-player-components)* exclude tests from publishing to crates.io
+- cleanup cargo dependencies
+
 ## [v0.1.0](https://github.com/x-software-com/mxl-player-components/compare/d26806803abd0210cf55ca70d5ee584783f6fef5..v0.1.0) - 2024-10-23
 #### Miscellaneous Chores
 - improve justfile and add setup guide to README.md - ([b80ba64](https://github.com/x-software-com/mxl-player-components/commit/b80ba64c46c0ba96de3feec9c82e0313d8bf5b54)) - marcbull

--- a/mxl-player-components/Cargo.toml
+++ b/mxl-player-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-player-components"
-version = "0.1.0"
+version = "0.1.1"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 exclude = ["tests"]

--- a/mxl-relm4-components/CHANGELOG.md
+++ b/mxl-relm4-components/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+
+## [0.2.3](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.2...mxl-relm4-components-v0.2.3) - 2024-11-20
+
+### Other
+
+- cleanup cargo dependencies
+
 ## [v0.2.2](https://github.com/x-software-com/mxl-relm4-components/compare/944ecf76f8bed1b21430455174d9580ffa638fd3..v0.2.2) - 2024-09-02
 #### Miscellaneous Chores
 - update i18n-embed-fl and i18n-embed versions - ([944ecf7](https://github.com/x-software-com/mxl-relm4-components/commit/944ecf76f8bed1b21430455174d9580ffa638fd3)) - acpiccolo

--- a/mxl-relm4-components/Cargo.toml
+++ b/mxl-relm4-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-relm4-components"
-version = "0.2.2"
+version = "0.2.3"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `mxl-base`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `mxl-investigator`: 0.1.18 -> 0.1.19 (✓ API compatible changes)
* `mxl-relm4-components`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `mxl-player-components`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mxl-base`
<blockquote>

## [0.2.5](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.4...mxl-base-v0.2.5) - 2024-11-20

### Other

- cleanup cargo dependencies
</blockquote>

## `mxl-investigator`
<blockquote>

## [0.1.19](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.18...mxl-investigator-v0.1.19) - 2024-11-20

### Other

- *(mxl-investigator)* fix nightly clippy warning
- *(mxl-investigator)* fix unused_variables warning when sysinfo feature is disabled
- cleanup cargo dependencies
</blockquote>

## `mxl-relm4-components`
<blockquote>

## [0.2.3](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.2...mxl-relm4-components-v0.2.3) - 2024-11-20

### Other

- cleanup cargo dependencies
</blockquote>

## `mxl-player-components`
<blockquote>

## [0.1.1](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.0...mxl-player-components-v0.1.1) - 2024-11-20

### Other

- *(mxl-player-components)* exclude tests from publishing to crates.io
- cleanup cargo dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).