### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ i18n-embed = { version = "0.15", features = [
     "desktop-requester",
 ] }
 
-mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.3" }
+mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.4" }

--- a/mxl-base/CHANGELOG.md
+++ b/mxl-base/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.6](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.5...mxl-base-v0.2.6) - 2024-12-12
+
+### Other
+
+- replaced once_cell dependency
+
 ## [0.2.5](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.4...mxl-base-v0.2.5) - 2024-11-20
 
 ### Other

--- a/mxl-base/Cargo.toml
+++ b/mxl-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-base"
-version = "0.2.5"
+version = "0.2.6"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true

--- a/mxl-investigator/CHANGELOG.md
+++ b/mxl-investigator/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.20](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.19...mxl-investigator-v0.1.20) - 2024-12-12
+
+### Other
+
+- *(deps)* update sysinfo requirement from 0.32 to 0.33
+- replaced dependency backtrace
+- *(deps)* update fs4 requirement from 0.11 to 0.12
+- replaced once_cell dependency
+
 ## [0.1.19](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.18...mxl-investigator-v0.1.19) - 2024-11-20
 
 ### Other

--- a/mxl-investigator/Cargo.toml
+++ b/mxl-investigator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-investigator"
-version = "0.1.19"
+version = "0.1.20"
 description = "This is a component of the X-Software MXL product line."
 readme = "README.md"
 license.workspace = true

--- a/mxl-player-components/CHANGELOG.md
+++ b/mxl-player-components/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.2](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.1...mxl-player-components-v0.1.2) - 2024-12-12
+
+### Other
+
+- replaced once_cell dependency
+- *(mxl-player-components)* improve integration tests
+
 ## [0.1.1](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.0...mxl-player-components-v0.1.1) - 2024-11-20
 
 ### Other

--- a/mxl-player-components/Cargo.toml
+++ b/mxl-player-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-player-components"
-version = "0.1.1"
+version = "0.1.2"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 exclude = ["tests"]

--- a/mxl-relm4-components/CHANGELOG.md
+++ b/mxl-relm4-components/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.4](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.3...mxl-relm4-components-v0.2.4) - 2024-12-12
+
+### Other
+
+- replaced once_cell dependency
+
 ## [0.2.3](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.2...mxl-relm4-components-v0.2.3) - 2024-11-20
 
 ### Other

--- a/mxl-relm4-components/Cargo.toml
+++ b/mxl-relm4-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-relm4-components"
-version = "0.2.3"
+version = "0.2.4"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `mxl-base`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `mxl-investigator`: 0.1.19 -> 0.1.20 (✓ API compatible changes)
* `mxl-relm4-components`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `mxl-player-components`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mxl-base`
<blockquote>

## [0.2.6](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.5...mxl-base-v0.2.6) - 2024-12-12

### Other

- replaced once_cell dependency
</blockquote>

## `mxl-investigator`
<blockquote>

## [0.1.20](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.19...mxl-investigator-v0.1.20) - 2024-12-12

### Other

- *(deps)* update sysinfo requirement from 0.32 to 0.33
- replaced dependency backtrace
- *(deps)* update fs4 requirement from 0.11 to 0.12
- replaced once_cell dependency
</blockquote>

## `mxl-relm4-components`
<blockquote>

## [0.2.4](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.3...mxl-relm4-components-v0.2.4) - 2024-12-12

### Other

- replaced once_cell dependency
</blockquote>

## `mxl-player-components`
<blockquote>

## [0.1.2](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.1...mxl-player-components-v0.1.2) - 2024-12-12

### Other

- replaced once_cell dependency
- *(mxl-player-components)* improve integration tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).