### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ i18n-embed = { version = "0.15", features = [
     "desktop-requester",
 ] }
 
-mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.4" }
+mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.5" }

--- a/mxl-base/CHANGELOG.md
+++ b/mxl-base/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.7](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.6...mxl-base-v0.2.7) - 2025-02-27
+
+### Other
+
+- update rust edition to 2024
+- *(deps)* update directories requirement from 5 to 6
+
 ## [0.2.6](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.5...mxl-base-v0.2.6) - 2024-12-12
 
 ### Other

--- a/mxl-base/Cargo.toml
+++ b/mxl-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-base"
-version = "0.2.6"
+version = "0.2.7"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true

--- a/mxl-investigator/CHANGELOG.md
+++ b/mxl-investigator/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.22](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.21...mxl-investigator-v0.1.22) - 2025-02-27
+
+### Added
+
+- add button to open the report file directory, closes #13
+
+### Other
+
+- update rust edition to 2024
+
 ## [0.1.21](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.20...mxl-investigator-v0.1.21) - 2024-12-19
 
 ### Other

--- a/mxl-investigator/Cargo.toml
+++ b/mxl-investigator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-investigator"
-version = "0.1.21"
+version = "0.1.22"
 description = "This is a component of the X-Software MXL product line."
 readme = "README.md"
 license.workspace = true

--- a/mxl-player-components/CHANGELOG.md
+++ b/mxl-player-components/CHANGELOG.md
@@ -3,6 +3,25 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.3](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.2...mxl-player-components-v0.1.3) - 2025-02-27
+
+### Added
+
+- added button to retry failed metadata fetch attempts
+
+### Fixed
+
+- fix playlist issue when closing application while fetching metadata
+
+### Other
+
+- update rust edition to 2024
+- add shortcut to open the proc directory
+- *(deps)* update notify requirement from 7 to 8
+- *(deps)* update gst-plugin-gtk4 requirement from =0.13.1 to =0.13.4
+- fix clippy issue
+- fix cargo-machete issues
+
 ## [0.1.2](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.1...mxl-player-components-v0.1.2) - 2024-12-12
 
 ### Other

--- a/mxl-player-components/Cargo.toml
+++ b/mxl-player-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-player-components"
-version = "0.1.2"
+version = "0.1.3"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 exclude = ["tests"]

--- a/mxl-relm4-components/CHANGELOG.md
+++ b/mxl-relm4-components/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.5](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.4...mxl-relm4-components-v0.2.5) - 2025-02-27
+
+### Other
+
+- update rust edition to 2024
+
 ## [0.2.4](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.3...mxl-relm4-components-v0.2.4) - 2024-12-12
 
 ### Other

--- a/mxl-relm4-components/Cargo.toml
+++ b/mxl-relm4-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-relm4-components"
-version = "0.2.4"
+version = "0.2.5"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mxl-base`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `mxl-relm4-components`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `mxl-investigator`: 0.1.21 -> 0.1.22 (✓ API compatible changes)
* `mxl-player-components`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mxl-base`

<blockquote>

## [0.2.7](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.6...mxl-base-v0.2.7) - 2025-02-27

### Other

- update rust edition to 2024
- *(deps)* update directories requirement from 5 to 6
</blockquote>

## `mxl-relm4-components`

<blockquote>

## [0.2.5](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.4...mxl-relm4-components-v0.2.5) - 2025-02-27

### Other

- update rust edition to 2024
</blockquote>

## `mxl-investigator`

<blockquote>

## [0.1.22](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.21...mxl-investigator-v0.1.22) - 2025-02-27

### Added

- add button to open the report file directory, closes #13

### Other

- update rust edition to 2024
</blockquote>

## `mxl-player-components`

<blockquote>

## [0.1.3](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.2...mxl-player-components-v0.1.3) - 2025-02-27

### Added

- added button to retry failed metadata fetch attempts

### Fixed

- fix playlist issue when closing application while fetching metadata

### Other

- update rust edition to 2024
- add shortcut to open the proc directory
- *(deps)* update notify requirement from 7 to 8
- *(deps)* update gst-plugin-gtk4 requirement from =0.13.1 to =0.13.4
- fix clippy issue
- fix cargo-machete issues
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).