### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ i18n-embed = { version = "0.15", features = [
     "desktop-requester",
 ] }
 
-mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.5" }
+mxl-relm4-components = { path = "mxl-relm4-components", version = "0.2.6" }

--- a/mxl-base/CHANGELOG.md
+++ b/mxl-base/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.8](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.7...mxl-base-v0.2.8) - 2025-07-04
+
+### Other
+
+- fix clippy warnings, use variables directly in the format string
+- correct typo in function name
+- update README links to point to mxl-crates
+- correct typo in comment
+
 ## [0.2.7](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.6...mxl-base-v0.2.7) - 2025-02-27
 
 ### Other

--- a/mxl-base/Cargo.toml
+++ b/mxl-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-base"
-version = "0.2.7"
+version = "0.2.8"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true

--- a/mxl-investigator/CHANGELOG.md
+++ b/mxl-investigator/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.24](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.23...mxl-investigator-v0.1.24) - 2025-07-04
+
+### Other
+
+- *(deps)* update zip requirement from 2 to 4
+- *(deps)* update sysinfo requirement from 0.33 to 0.35
+- fix clippy warnings, use variables directly in the format string
+- update README links to point to mxl-crates
+- correct typo in comment
+- fix clippy issues
+
 ## [0.1.23](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.22...mxl-investigator-v0.1.23) - 2025-03-05
 
 ### Other

--- a/mxl-investigator/Cargo.toml
+++ b/mxl-investigator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-investigator"
-version = "0.1.23"
+version = "0.1.24"
 description = "This is a component of the X-Software MXL product line."
 readme = "README.md"
 license.workspace = true

--- a/mxl-player-components/CHANGELOG.md
+++ b/mxl-player-components/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.4](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.3...mxl-player-components-v0.1.4) - 2025-07-04
+
+### Other
+
+- *(deps)* update gst-plugin-gtk4 requirement from =0.13.4 to =0.13.6
+- fix clippy warnings, use variables directly in the format string
+- update README links to point to mxl-crates
+- correct typo in comment
+- fix clippy issues
+
 ## [0.1.3](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.2...mxl-player-components-v0.1.3) - 2025-02-27
 
 ### Added

--- a/mxl-player-components/Cargo.toml
+++ b/mxl-player-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-player-components"
-version = "0.1.3"
+version = "0.1.4"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 exclude = ["tests"]

--- a/mxl-relm4-components/CHANGELOG.md
+++ b/mxl-relm4-components/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.6](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.5...mxl-relm4-components-v0.2.6) - 2025-07-04
+
+### Other
+
+- update README links to point to mxl-crates
+- correct typo in comment
+- fix clippy issues
+
 ## [0.2.5](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.4...mxl-relm4-components-v0.2.5) - 2025-02-27
 
 ### Other

--- a/mxl-relm4-components/Cargo.toml
+++ b/mxl-relm4-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mxl-relm4-components"
-version = "0.2.5"
+version = "0.2.6"
 description = "This is a component of the X-Software MXL product line"
 readme = "README.md"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `mxl-base`: 0.2.7 -> 0.2.8 (✓ API compatible changes)
* `mxl-relm4-components`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `mxl-investigator`: 0.1.23 -> 0.1.24 (✓ API compatible changes)
* `mxl-player-components`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mxl-base`

<blockquote>

## [0.2.8](https://github.com/x-software-com/mxl-crates/compare/mxl-base-v0.2.7...mxl-base-v0.2.8) - 2025-07-04

### Other

- fix clippy warnings, use variables directly in the format string
- correct typo in function name
- update README links to point to mxl-crates
- correct typo in comment
</blockquote>

## `mxl-relm4-components`

<blockquote>

## [0.2.6](https://github.com/x-software-com/mxl-crates/compare/mxl-relm4-components-v0.2.5...mxl-relm4-components-v0.2.6) - 2025-07-04

### Other

- update README links to point to mxl-crates
- correct typo in comment
- fix clippy issues
</blockquote>

## `mxl-investigator`

<blockquote>

## [0.1.24](https://github.com/x-software-com/mxl-crates/compare/mxl-investigator-v0.1.23...mxl-investigator-v0.1.24) - 2025-07-04

### Other

- *(deps)* update zip requirement from 2 to 4
- *(deps)* update sysinfo requirement from 0.33 to 0.35
- fix clippy warnings, use variables directly in the format string
- update README links to point to mxl-crates
- correct typo in comment
- fix clippy issues
</blockquote>

## `mxl-player-components`

<blockquote>

## [0.1.4](https://github.com/x-software-com/mxl-crates/compare/mxl-player-components-v0.1.3...mxl-player-components-v0.1.4) - 2025-07-04

### Other

- *(deps)* update gst-plugin-gtk4 requirement from =0.13.4 to =0.13.6
- fix clippy warnings, use variables directly in the format string
- update README links to point to mxl-crates
- correct typo in comment
- fix clippy issues
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).