### PR TITLE
feat: allow to set qos and max_lateness

### DIFF
--- a/mxl-player-components/src/ui/player/model.rs
+++ b/mxl-player-components/src/ui/player/model.rs
@@ -1,4 +1,4 @@
-use crate::player::{Player, PlayerBuilder};
+use crate::player::{MaxLateness, Player, PlayerBuilder};
 use crate::ui::player::messages::PlaybackState;
 use log::*;
 use mxl_relm4_components::relm4::{gtk, gtk::prelude::*};
@@ -10,6 +10,8 @@ pub struct PlayerComponentInit {
     pub seek_accurate: bool,
     pub show_seeking_overlay: bool,
     pub compositor: Option<gst::Element>,
+    pub qos: bool,
+    pub max_lateness: MaxLateness,
     pub draw_callback: Box<DrawCallbackFn>,
     pub drag_gesture: Option<gtk::GestureDrag>,
     pub motion_tracker: Option<gtk::EventControllerMotion>,

--- a/mxl-player-components/tests/player/app.rs
+++ b/mxl-player-components/tests/player/app.rs
@@ -3,6 +3,7 @@ use log::*;
 use mxl_player_components::{
     actions::{self, Accelerators},
     gst_play::PlayMediaInfo,
+    player::MaxLateness,
     ui::{
         player::{
             messages::{PlaybackState, PlayerComponentInput, PlayerComponentOutput},
@@ -218,6 +219,8 @@ impl Component for App {
                     show_seeking_overlay: false,
                     seek_accurate: false,
                     compositor: None,
+                    qos: true,
+                    max_lateness: MaxLateness::Default,
                     draw_callback: Box::new(|_, _| {}),
                     drag_gesture: None,
                     motion_tracker: None,


### PR DESCRIPTION
The qos value enables or disables the generation of Quality-of-Service upstream events. The mx_lateness sets the maximum number of nanoseconds that a buffer can be late before it is dropped or unlimited.